### PR TITLE
chore: upgrade deps, rename compact.cirru, bump to 0.0.10

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,15 +14,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: calcit-lang/setup-cr@0.0.8
+      - uses: calcit-lang/setup-cr@0.0.9
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: nightly
 
       - uses: Swatinem/rust-cache@v2
 
       - run: cargo build --release
+
+      - run: cargo clippy -- -D warnings
 
       - run: rm -rfv dylibs/* && mkdir -p dylibs/ && ls target/release/ && cp -v target/release/*.* dylibs/
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
+          components: clippy
 
       - uses: Swatinem/rust-cache@v2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cirru_edn"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47f4173f6758afa15d0ad76bb9013a17b8a7da89a05e2b2a60cbc6b0c071ee9"
+checksum = "0a3d754e1ea42cbeffaa32f3e3a80f32a709e935c697d716a89423975c9c7653"
 dependencies = [
  "cirru_parser",
  "cjk",
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "cirru_parser"
-version = "0.2.4"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd74f684ca880e0f809554c676d1cede0bc688a0b184b62adef58f5e52b22ed"
+checksum = "a4c653542a798accd63a555315805cc54f25075e927e2cd893ba1f5662107252"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ crate-type = ["dylib"] # Creates dynamic lib
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cirru_edn = "0.7.4"
-cirru_parser = "0.2.4"
+cirru_edn = "0.7.7"
+cirru_parser = "0.2.8"
 reqwest = { version = "0.11.20", features = ["blocking"] }

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
-{} (:about "|file is generated - never edit directly; learn cr edit/tree workflows before changing") (:package |fetch)
-  :configs $ {} (:init-fn |fetch.test/main!) (:reload-fn |fetch.test/reload!) (:version |0.0.9)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |fetch)
+  :configs $ {} (:init-fn |fetch.test/main!) (:reload-fn |fetch.test/reload!) (:version |0.0.10)
     :modules $ []
   :entries $ {}
   :files $ {}
@@ -9,14 +9,13 @@
         |fetch $ %{} :CodeEntry (:doc "|Asynchronously sends an HTTP request through the native fetch dylib.\nParams: url (string), options (nil or map), cb (callback receiving (:: :ok string) or (:: :err string)).\nReturns: unit immediately; response is delivered through callback.")
           :code $ quote
             defn fetch (url options cb)
-              &call-dylib-edn-fn (get-dylib-path "\"/dylibs/libcalcit_http") "\"fetch" url options cb
+              &call-dylib-edn-fn (get-dylib-path |/dylibs/libcalcit_http) |fetch url options cb
           :examples $ []
             quote $ quote
               fetch |https://calcit-lang.org nil $ fn (info)
                 tag-match info
-                    :ok text
-                    println text
-                  (:err e) (println "\"Err" e)
+                  (:ok text) (println text)
+                  (:err e) (println |Err e)
           :schema $ :: :fn
             {} (:return :unit)
               :args $ [] :string :dynamic
@@ -45,23 +44,21 @@
               :args $ []
         |run-tests $ %{} :CodeEntry (:doc "|Prints module info and demonstrates an async GET request.")
           :code $ quote
-            defn run-tests () (println "\"%%%% test for lib") (println calcit-filename calcit-dirname)
-              fetch "\"http://calcit-lang.org" nil $ fn (info)
+            defn run-tests () (println "|%%%% test for lib") (println calcit-filename calcit-dirname)
+              fetch |http://calcit-lang.org nil $ fn (info)
                 tag-match info
-                    :ok text
-                    println text
-                  (:err e) (println "\"Err" e)
-              ; fetch "\"http://localhost:4000/demo"
+                  (:ok text) (println text)
+                  (:err e) (println |Err e)
+              ; fetch |http://localhost:4000/demo
                 {} (:method :POST)
                   :headers $ {} (:a |b)
                   :query $ [] ([] :a |b) ([] :c |d)
                   :body "|Some body"
                 fn (info)
                   tag-match info
-                      :ok text
-                      println text
-                    (:err e) (println "\"Err" e)
-              println "\"sent request"
+                    (:ok text) (println text)
+                    (:err e) (println |Err e)
+              println "|sent request"
           :examples $ []
           :schema $ :: :fn
             {} (:return :unit)
@@ -73,9 +70,9 @@
             fetch.$meta :refer $ calcit-dirname calcit-filename
     |fetch.util $ %{} :FileEntry
       :defs $ {}
-        |get-dylib-ext $ %{} :CodeEntry (:doc "|Resolves platform-specific dylib extension for the current OS.") (:schema nil)
+        |get-dylib-ext $ %{} :CodeEntry (:doc "|Resolves platform-specific dylib extension for the current OS.") (:schema :dynamic)
           :code $ quote
-            defmacro get-dylib-ext () $ case-default (&get-os) "\".so" (:macos "\".dylib") (:windows "\".dll")
+            defmacro get-dylib-ext () $ case-default (&get-os) |.so (:macos |.dylib) (:windows |.dll)
           :examples $ []
         |get-dylib-path $ %{} :CodeEntry (:doc "|Builds a dylib path relative to current module directory.")
           :code $ quote
@@ -88,7 +85,7 @@
         |or-current-path $ %{} :CodeEntry (:doc "|Normalizes blank directory path to current directory marker.")
           :code $ quote
             defn or-current-path (p)
-              if (blank? p) "\"." p
+              if (blank? p) |. p
           :examples $ []
           :schema $ :: :fn
             {} (:return :string)

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,2 +1,2 @@
 {}
-  :calcit-version |0.12.14
+  :calcit-version |0.12.35


### PR DESCRIPTION
- cirru_edn 0.7.4 → 0.7.7
- cirru_parser 0.2.4 → 0.2.8
- calcit-version 0.12.14 → 0.12.35
- CI: setup-cr 0.0.8 → 0.0.9, toolchain nightly + clippy
- rename compact.cirru → calcit.cirru
- bump version to 0.0.10